### PR TITLE
Changes required in text-cache module for implementing break lines, sub & superscripts as well as bold & italic styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -399,8 +399,8 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83",
-      "from": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83",
+      "version": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887",
+      "from": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -399,8 +399,8 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb",
-      "from": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb",
+      "version": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c",
+      "from": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -399,9 +399,8 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "vectorize-text": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/vectorize-text/-/vectorize-text-3.0.2.tgz",
-      "integrity": "sha1-BasWMOQJ83eWTiuSBbLVWakvYNg=",
+      "version": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2",
+      "from": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -399,8 +399,8 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12",
-      "from": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12",
+      "version": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83",
+      "from": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -399,8 +399,8 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e",
-      "from": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e",
+      "version": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0",
+      "from": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -399,8 +399,9 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0",
-      "from": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vectorize-text/-/vectorize-text-3.2.0.tgz",
+      "integrity": "sha512-N3eldFPkXY7mVK1aBuKPdQKYerBSPEAf+4Tl6DGdnVb1MZ8buD9SKv5TUCyRCEe5KblC56MoJcmf0I/IyGjOGQ==",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -399,8 +399,8 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2",
-      "from": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2",
+      "version": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12",
+      "from": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,424 @@
+{
+  "name": "text-cache",
+  "version": "4.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "big-rat": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/big-rat/-/big-rat-1.0.4.tgz",
+      "integrity": "sha1-do0JO7V5MN0Y7Vdcf8on3FORreo=",
+      "requires": {
+        "bit-twiddle": "^1.0.2",
+        "bn.js": "^4.11.6",
+        "double-bits": "^1.1.1"
+      }
+    },
+    "binary-search-bounds": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
+      "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
+    },
+    "bit-twiddle": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
+      "integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4="
+    },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+    },
+    "box-intersect": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
+      "integrity": "sha1-tyilnj8aPHPCJJM8JmC5J6oTeQI=",
+      "requires": {
+        "bit-twiddle": "^1.0.2",
+        "typedarray-pool": "^1.1.0"
+      }
+    },
+    "cdt2d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cdt2d/-/cdt2d-1.0.0.tgz",
+      "integrity": "sha1-TyEkNLzWe9s9aLj+9KzcLFRBUUE=",
+      "requires": {
+        "binary-search-bounds": "^2.0.3",
+        "robust-in-sphere": "^1.1.3",
+        "robust-orientation": "^1.1.3"
+      }
+    },
+    "clean-pslg": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/clean-pslg/-/clean-pslg-1.1.2.tgz",
+      "integrity": "sha1-vTXHRgt+irWp92Gl7VF5aqPIbBE=",
+      "requires": {
+        "big-rat": "^1.0.3",
+        "box-intersect": "^1.0.1",
+        "nextafter": "^1.0.0",
+        "rat-vec": "^1.1.1",
+        "robust-segment-intersect": "^1.0.1",
+        "union-find": "^1.0.2",
+        "uniq": "^1.0.1"
+      }
+    },
+    "compare-angle": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/compare-angle/-/compare-angle-1.0.1.tgz",
+      "integrity": "sha1-pOtjQW6jx0f8a9bItjZotN5PoSk=",
+      "requires": {
+        "robust-orientation": "^1.0.2",
+        "robust-product": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "signum": "^0.0.0",
+        "two-sum": "^1.0.0"
+      }
+    },
+    "cwise-compiler": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
+      "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
+      "requires": {
+        "uniq": "^1.0.0"
+      }
+    },
+    "double-bits": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/double-bits/-/double-bits-1.1.1.tgz",
+      "integrity": "sha1-WKu6RUlNpND6Nrc60RoobJGEscY="
+    },
+    "dup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
+      "integrity": "sha1-UfxaxoX4GWRp3wuQXpNLIK9bQCk="
+    },
+    "edges-to-adjacency-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/edges-to-adjacency-list/-/edges-to-adjacency-list-1.0.0.tgz",
+      "integrity": "sha1-wUbS4ISt37p0pRKTxuAZmkn3V/E=",
+      "requires": {
+        "uniq": "^1.0.0"
+      }
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
+    "gamma": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/gamma/-/gamma-0.1.0.tgz",
+      "integrity": "sha1-MxVkNAO/J5BsqAqzfDbs6UQO8zA="
+    },
+    "interval-tree-1d": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/interval-tree-1d/-/interval-tree-1d-1.0.3.tgz",
+      "integrity": "sha1-j9veArayx9verWNry+2OCHENhcE=",
+      "requires": {
+        "binary-search-bounds": "^1.0.0"
+      },
+      "dependencies": {
+        "binary-search-bounds": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
+          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+        }
+      }
+    },
+    "invert-permutation": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-permutation/-/invert-permutation-1.0.0.tgz",
+      "integrity": "sha1-oKeAQurbNrwXVR54fv0UOa3VSTM="
+    },
+    "iota-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
+      "integrity": "sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc="
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "ndarray": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.18.tgz",
+      "integrity": "sha1-tg06cyJOxVXQ+qeXEeUCRI/T95M=",
+      "requires": {
+        "iota-array": "^1.0.0",
+        "is-buffer": "^1.0.2"
+      }
+    },
+    "ndarray-extract-contour": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ndarray-extract-contour/-/ndarray-extract-contour-1.0.1.tgz",
+      "integrity": "sha1-Cu4ROjozsia5DEiIz4d79HUTBeQ=",
+      "requires": {
+        "typedarray-pool": "^1.0.0"
+      }
+    },
+    "nextafter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nextafter/-/nextafter-1.0.0.tgz",
+      "integrity": "sha1-t9d7U1MQ4+CX5gJauwqQNHfsGjo=",
+      "requires": {
+        "double-bits": "^1.1.0"
+      }
+    },
+    "permutation-parity": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/permutation-parity/-/permutation-parity-1.0.0.tgz",
+      "integrity": "sha1-AXTVH8pwSxG5pLFSsj1Tf9xrXvQ=",
+      "requires": {
+        "typedarray-pool": "^1.0.0"
+      }
+    },
+    "permutation-rank": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/permutation-rank/-/permutation-rank-1.0.0.tgz",
+      "integrity": "sha1-n9mLvOzwj79ZlLXq3JSmLmeUg7U=",
+      "requires": {
+        "invert-permutation": "^1.0.0",
+        "typedarray-pool": "^1.0.0"
+      }
+    },
+    "planar-dual": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/planar-dual/-/planar-dual-1.0.2.tgz",
+      "integrity": "sha1-tqQjVSOxsMt55fkm+OozXdmC1WM=",
+      "requires": {
+        "compare-angle": "^1.0.0",
+        "dup": "^1.0.0"
+      }
+    },
+    "planar-graph-to-polyline": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/planar-graph-to-polyline/-/planar-graph-to-polyline-1.0.5.tgz",
+      "integrity": "sha1-iCuGBRmbqIv9RkyVUzA1VsUrmIo=",
+      "requires": {
+        "edges-to-adjacency-list": "^1.0.0",
+        "planar-dual": "^1.0.0",
+        "point-in-big-polygon": "^2.0.0",
+        "robust-orientation": "^1.0.1",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0",
+        "uniq": "^1.0.0"
+      }
+    },
+    "point-in-big-polygon": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/point-in-big-polygon/-/point-in-big-polygon-2.0.0.tgz",
+      "integrity": "sha1-ObYT6mzxfWtD4Yj3fzTETGszulU=",
+      "requires": {
+        "binary-search-bounds": "^1.0.0",
+        "interval-tree-1d": "^1.0.1",
+        "robust-orientation": "^1.1.3",
+        "slab-decomposition": "^1.0.1"
+      },
+      "dependencies": {
+        "binary-search-bounds": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
+          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+        }
+      }
+    },
+    "rat-vec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rat-vec/-/rat-vec-1.1.1.tgz",
+      "integrity": "sha1-Dd4rZrezS7G80qI4BerIBth/0X8=",
+      "requires": {
+        "big-rat": "^1.0.3"
+      }
+    },
+    "robust-in-sphere": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/robust-in-sphere/-/robust-in-sphere-1.1.3.tgz",
+      "integrity": "sha1-HFiD0WpOkjkpR27zSBmFe/Kpz3U=",
+      "requires": {
+        "robust-scale": "^1.0.0",
+        "robust-subtract": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0"
+      }
+    },
+    "robust-orientation": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.1.3.tgz",
+      "integrity": "sha1-2v9bANO+TmByLw6cAVbvln8cIEk=",
+      "requires": {
+        "robust-scale": "^1.0.2",
+        "robust-subtract": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.2"
+      }
+    },
+    "robust-product": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-product/-/robust-product-1.0.0.tgz",
+      "integrity": "sha1-aFJQAHzbunzx3nW/9tKScBEJir4=",
+      "requires": {
+        "robust-scale": "^1.0.0",
+        "robust-sum": "^1.0.0"
+      }
+    },
+    "robust-scale": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
+      "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
+      "requires": {
+        "two-product": "^1.0.2",
+        "two-sum": "^1.0.0"
+      }
+    },
+    "robust-segment-intersect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/robust-segment-intersect/-/robust-segment-intersect-1.0.1.tgz",
+      "integrity": "sha1-MlK2oPwboUreaRXMvgnLzpqrHBw=",
+      "requires": {
+        "robust-orientation": "^1.1.3"
+      }
+    },
+    "robust-subtract": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-subtract/-/robust-subtract-1.0.0.tgz",
+      "integrity": "sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo="
+    },
+    "robust-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-sum/-/robust-sum-1.0.0.tgz",
+      "integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k="
+    },
+    "signum": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/signum/-/signum-0.0.0.tgz",
+      "integrity": "sha1-q1UbEAM1EHCnBHg/GgnF52kfnPY="
+    },
+    "simplicial-complex": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-0.3.3.tgz",
+      "integrity": "sha1-TDDK1X+eRXKd2PMGyHU1efRr6Z4=",
+      "requires": {
+        "bit-twiddle": "~0.0.1",
+        "union-find": "~0.0.3"
+      },
+      "dependencies": {
+        "bit-twiddle": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-0.0.2.tgz",
+          "integrity": "sha1-wurruVKjuUrMFASX4c3NLxoz9Y4="
+        },
+        "union-find": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/union-find/-/union-find-0.0.4.tgz",
+          "integrity": "sha1-uFSzMBYZva0USwAUx4+W6sDS8PY="
+        }
+      }
+    },
+    "simplify-planar-graph": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/simplify-planar-graph/-/simplify-planar-graph-2.0.1.tgz",
+      "integrity": "sha1-vIWJNyXzLo+oriVoE5hEbSy892Y=",
+      "requires": {
+        "robust-orientation": "^1.0.1",
+        "simplicial-complex": "^0.3.3"
+      }
+    },
+    "slab-decomposition": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/slab-decomposition/-/slab-decomposition-1.0.2.tgz",
+      "integrity": "sha1-He1WdU1AixBznxRRA9/GGAf2UTQ=",
+      "requires": {
+        "binary-search-bounds": "^1.0.0",
+        "functional-red-black-tree": "^1.0.0",
+        "robust-orientation": "^1.1.3"
+      },
+      "dependencies": {
+        "binary-search-bounds": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
+          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+        }
+      }
+    },
+    "surface-nets": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/surface-nets/-/surface-nets-1.0.2.tgz",
+      "integrity": "sha1-5DPIy7qUpydMb0yZVStGG/H8eks=",
+      "requires": {
+        "ndarray-extract-contour": "^1.0.0",
+        "triangulate-hypercube": "^1.0.0",
+        "zero-crossings": "^1.0.0"
+      }
+    },
+    "triangulate-hypercube": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/triangulate-hypercube/-/triangulate-hypercube-1.0.1.tgz",
+      "integrity": "sha1-2Acdsuv8/VHzCNC88qXEils20Tc=",
+      "requires": {
+        "gamma": "^0.1.0",
+        "permutation-parity": "^1.0.0",
+        "permutation-rank": "^1.0.0"
+      }
+    },
+    "triangulate-polyline": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/triangulate-polyline/-/triangulate-polyline-1.0.3.tgz",
+      "integrity": "sha1-v4uod6hQVBA/65+lphtOjXAXgU0=",
+      "requires": {
+        "cdt2d": "^1.0.0"
+      }
+    },
+    "two-product": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/two-product/-/two-product-1.0.2.tgz",
+      "integrity": "sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo="
+    },
+    "two-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/two-sum/-/two-sum-1.0.0.tgz",
+      "integrity": "sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q="
+    },
+    "typedarray-pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.1.0.tgz",
+      "integrity": "sha1-0RT0hIAUifU+yrXoCIqiMET0mNk=",
+      "requires": {
+        "bit-twiddle": "^1.0.0",
+        "dup": "^1.0.0"
+      }
+    },
+    "union-find": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/union-find/-/union-find-1.0.2.tgz",
+      "integrity": "sha1-KSusQV5q06iVNdI3AQ20pTYoTlg="
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+    },
+    "vectorize-text": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vectorize-text/-/vectorize-text-3.0.2.tgz",
+      "integrity": "sha1-BasWMOQJ83eWTiuSBbLVWakvYNg=",
+      "requires": {
+        "cdt2d": "^1.0.0",
+        "clean-pslg": "^1.1.0",
+        "ndarray": "^1.0.11",
+        "planar-graph-to-polyline": "^1.0.0",
+        "simplify-planar-graph": "^2.0.1",
+        "surface-nets": "^1.0.0",
+        "triangulate-polyline": "^1.0.0"
+      }
+    },
+    "zero-crossings": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/zero-crossings/-/zero-crossings-1.0.1.tgz",
+      "integrity": "sha1-xWK9MRNkPzRDokXRJAa4i2m5qf8=",
+      "requires": {
+        "cwise-compiler": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -399,8 +399,8 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887",
-      "from": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887",
+      "version": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb",
+      "from": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -399,8 +399,8 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10",
-      "from": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10",
+      "version": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e",
+      "from": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -399,8 +399,8 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c",
-      "from": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c",
+      "version": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10",
+      "from": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "dependencies": {
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "dependencies": {
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "dependencies": {
-    "vectorize-text": "^3.0.1"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "dependencies": {
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "dependencies": {
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "dependencies": {
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "dependencies": {
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "dependencies": {
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0"
+    "vectorize-text": "^3.2.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "dependencies": {
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "dependencies": {
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0"
   },
   "devDependencies": {},
   "scripts": {

--- a/textcache.js
+++ b/textcache.js
@@ -32,55 +32,62 @@ function unwrap(mesh) {
 function textGet(font, text, opts) {
   var opts = opts || {}
   var fontcache = __TEXT_CACHE[font]
-   if(!fontcache) {
-     fontcache = __TEXT_CACHE[font] = {
-       ' ': {
-         data:   new Float32Array(0),
-         shape: 0.2
-       }
-     }
-   }
-   var mesh = fontcache[text]
-   if(!mesh) {
-     if(text.length <= 1 || !/\d/.test(text)) {
-       mesh = fontcache[text] = unwrap(vectorizeText(text, {
-         triangles:     true,
-         font:          font,
-         textAlign:     opts.textAlign || 'left',
-         textBaseline:  'alphabetic'
-       }))
-     } else {
-       var parts = text.split(/(\d|\s)/)
-       var buffer = new Array(parts.length)
-       var bufferSize = 0
-       var shapeX = 0
-       for(var i=0; i<parts.length; ++i) {
-         buffer[i] = textGet(font, parts[i])
-         bufferSize += buffer[i].data.length
-         shapeX += buffer[i].shape
-         if(i>0) {
-           shapeX += 0.02
-         }
-       }
+  if(!fontcache) {
+    fontcache = __TEXT_CACHE[font] = {
+      ' ': {
+        data:   new Float32Array(0),
+        shape: 0.2
+      }
+    }
+  }
+  var mesh = fontcache[text]
+  if(!mesh) {
+    if(text.length <= 1 || !/\d/.test(text)) {
+      mesh = fontcache[text] = unwrap(vectorizeText(text, {
+        triangles:     true,
+        font:          font,
+        textAlign:     opts.textAlign || 'left',
+        textBaseline:  'alphabetic',
+        styletags: {
+            breaklines: true,
+                 bolds: true,
+               italics: true,
+            subscripts: true,
+          superscripts: true
+        }
+      }))
+    } else {
+      var parts = text.split(/(\d|\s)/)
+      var buffer = new Array(parts.length)
+      var bufferSize = 0
+      var shapeX = 0
+      for(var i=0; i<parts.length; ++i) {
+        buffer[i] = textGet(font, parts[i])
+        bufferSize += buffer[i].data.length
+        shapeX += buffer[i].shape
+        if(i>0) {
+          shapeX += 0.02
+        }
+      }
 
-       var data = new Float32Array(bufferSize)
-       var ptr     = 0
-       var xOffset = -0.5 * shapeX
-       for(var i=0; i<buffer.length; ++i) {
-         var bdata = buffer[i].data
-         for(var j=0; j<bdata.length; j+=2) {
-           data[ptr++] = bdata[j] + xOffset
-           data[ptr++] = bdata[j+1]
-         }
-         xOffset += buffer[i].shape + 0.02
-       }
+      var data = new Float32Array(bufferSize)
+      var ptr     = 0
+      var xOffset = -0.5 * shapeX
+      for(var i=0; i<buffer.length; ++i) {
+        var bdata = buffer[i].data
+        for(var j=0; j<bdata.length; j+=2) {
+          data[ptr++] = bdata[j] + xOffset
+          data[ptr++] = bdata[j+1]
+        }
+        xOffset += buffer[i].shape + 0.02
+      }
 
-       mesh = fontcache[text] = {
-         data:  data,
-         shape: shapeX
-       }
-     }
-   }
+      mesh = fontcache[text] = {
+        data:  data,
+        shape: shapeX
+      }
+    }
+  }
 
    return mesh
 }


### PR DESCRIPTION
This PR is making use of the latest options in `vectorize-text` that enables tags namely < b > < i > < sup > < sub> and < br > within webGL texts.
Please also refer to [Plotly PR 3207](https://github.com/plotly/plotly.js/pull/3207) for more information.
@etpinard 
@alexcjohnson 